### PR TITLE
Add missing dependency on zlib

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>message_filters</build_depend>
+  <build_depend>zlib</build_depend>
   
   <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
   <exec_depend>qtbase5-dev</exec_depend>
@@ -45,6 +46,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>message_filters</exec_depend>
+  <exec_depend>zlib</exec_depend>
   
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>


### PR DESCRIPTION
Unconditionally required here: https://github.com/cottsay/find-object/blob/635efcd6220cabc258b88c54b1ae4279035bbe31/CMakeLists.txt#L134

rosdep rules for `zlib`: https://github.com/ros/rosdistro/blob/eee874f940271cea17534d9cf9d87a526ba1dce2/rosdep/base.yaml#L8857-L8873

Should resolve RHEL 9 build failures on the buildfarm: https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__find_object_2d__rhel_9_x86_64__binary/

Thanks!