### PR TITLE
Replace ament_target_dependencies with target_link_libraries and message filter deprecations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 
 ### Qt Gui stuff ###
-SET(headers_ui 
+SET(headers_ui
    ../include/${PROJECT_PREFIX}/MainWindow.h
    ../include/${PROJECT_PREFIX}/FindObject.h
    ../include/${PROJECT_PREFIX}/Camera.h
@@ -17,14 +17,14 @@ SET(headers_ui
    ./utilite/UPlot.h
 )
 IF(CATKIN_BUILD)
-   SET(headers_ui  
+   SET(headers_ui
       ${headers_ui}
       ./ros1/CameraROS.h
       ./ros1/FindObjectROS.h
    )
 ENDIF(CATKIN_BUILD)
 IF(COLCON_BUILD)
-   SET(headers_ui  
+   SET(headers_ui
       ${headers_ui}
       ./ros2/CameraROS.h
       ./ros2/FindObjectROS.h
@@ -37,7 +37,7 @@ SET(uis
    ./ui/aboutDialog.ui
 )
 
-SET(qrc 
+SET(qrc
    ./resources.qrc
 )
 
@@ -57,7 +57,7 @@ ELSE()
     QT5_WRAP_CPP(moc_srcs ${headers_ui})
 ENDIF()
 
-SET(SRC_FILES 
+SET(SRC_FILES
    ./MainWindow.cpp
    ./AddObjectDialog.cpp
    ./KeypointItem.cpp
@@ -82,19 +82,19 @@ SET(SRC_FILES
    ./rtabmap/PdfPlot.cpp
    ./json/jsoncpp.cpp
    ./Compression.cpp
-   ${moc_srcs} 
-   ${moc_uis} 
+   ${moc_srcs}
+   ${moc_uis}
    ${srcs_qrc}
 )
 IF(CATKIN_BUILD)
-   SET(SRC_FILES 
+   SET(SRC_FILES
       ${SRC_FILES}
       ./ros1/CameraROS.cpp
       ./ros1/FindObjectROS.cpp
    )
 ENDIF(CATKIN_BUILD)
 IF(COLCON_BUILD)
-   SET(SRC_FILES 
+   SET(SRC_FILES
       ${SRC_FILES}
       ./ros2/CameraROS.cpp
       ./ros2/FindObjectROS.cpp
@@ -114,9 +114,9 @@ IF(QT4_FOUND)
 ENDIF(QT4_FOUND)
 
 SET(LIBRARIES
-   ${QT_LIBRARIES} 
-   ${OpenCV_LIBS} 
-   ${ZLIB_LIBRARIES} 
+   ${QT_LIBRARIES}
+   ${OpenCV_LIBS}
+   ${ZLIB_LIBRARIES}
 )
 IF(CATKIN_BUILD)
    SET(LIBRARIES
@@ -126,17 +126,17 @@ IF(CATKIN_BUILD)
 ENDIF(CATKIN_BUILD)
 IF(COLCON_BUILD)
    SET(AMENT_LIBRARIES
-      rclcpp
-      rclcpp_components
-      cv_bridge
-      sensor_msgs
-      std_msgs
-      image_transport
-      message_filters
-      tf2
-      tf2_ros
-      tf2_geometry_msgs
-      geometry_msgs
+      rclcpp::rclcpp
+      rclcpp_components::component
+      cv_bridge::cv_bridge
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+      image_transport::image_transport
+      message_filters::message_filters
+      tf2::tf2
+      tf2_ros::tf2_ros
+      ${tf2_geometry_msgs_TARGETS}
+      ${geometry_msgs_TARGETS}
    )
 ENDIF(COLCON_BUILD)
 
@@ -181,8 +181,8 @@ IF(CATKIN_BUILD)
    add_dependencies(find_object ${${PROJECT_NAME}_EXPORTED_TARGETS})
 ENDIF(CATKIN_BUILD)
 IF(COLCON_BUILD)
-   ament_target_dependencies(find_object ${AMENT_LIBRARIES})
-   
+   target_link_libraries(find_object ${AMENT_LIBRARIES})
+
    if("$ENV{ROS_DISTRO}" STRGREATER_EQUAL "humble")
       rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
       target_link_libraries(find_object ${cpp_typesupport_target} ${LIBRARIES})
@@ -203,7 +203,7 @@ IF(NOT ROS_BUILD)
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT runtime
       LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel
       ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
-      
+
    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/ DESTINATION "${INSTALL_INCLUDE_DIR}" COMPONENT devel FILES_MATCHING PATTERN "*.h" PATTERN ".svn" EXCLUDE)
 ELSEIF(CATKIN_BUILD)
    add_executable(find_object_2d ros1/find_object_2d_node.cpp)
@@ -216,7 +216,7 @@ ELSEIF(CATKIN_BUILD)
    add_executable(tf_example ros1/tf_example_node.cpp)
    target_link_libraries(tf_example ${LIBRARIES})
    add_dependencies(tf_example ${${PROJECT_NAME}_EXPORTED_TARGETS})
-   
+
    IF(Qt5_FOUND)
       QT5_USE_MODULES(find_object_2d Widgets Core Gui Network PrintSupport)
       QT5_USE_MODULES(print_objects_detected Widgets Core Gui Network PrintSupport)
@@ -224,11 +224,11 @@ ELSEIF(CATKIN_BUILD)
    ENDIF(Qt5_FOUND)
 
    ## Mark executables and/or libraries for installation
-   install(TARGETS 
+   install(TARGETS
       find_object
-      find_object_2d 
-      print_objects_detected 
-      tf_example 
+      find_object_2d
+      print_objects_detected
+      tf_example
       ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
       LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
       RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -236,17 +236,17 @@ ELSEIF(CATKIN_BUILD)
 ELSE() # COLCON_BUILD
    add_executable(find_object_2d_node ros2/find_object_2d_node.cpp)
    set_target_properties(find_object_2d_node PROPERTIES  OUTPUT_NAME find_object_2d)
-   ament_target_dependencies(find_object_2d_node ${AMENT_LIBRARIES})
+   target_link_libraries(find_object_2d_node ${AMENT_LIBRARIES})
    target_link_libraries(find_object_2d_node find_object ${LIBRARIES})
-   
+
    add_executable(print_objects_detected ros2/print_objects_detected_node.cpp)
-   ament_target_dependencies(print_objects_detected ${AMENT_LIBRARIES})
+   target_link_libraries(print_objects_detected ${AMENT_LIBRARIES})
    target_link_libraries(print_objects_detected find_object ${LIBRARIES})
-   
+
    add_executable(tf_example ros2/tf_example_node.cpp)
-   ament_target_dependencies(tf_example ${AMENT_LIBRARIES})
+   target_link_libraries(tf_example ${AMENT_LIBRARIES})
    target_link_libraries(tf_example find_object ${LIBRARIES})
-   
+
    # Only required when using messages built from the same package
    # https://index.ros.org/doc/ros2/Tutorials/Rosidl-Tutorial/
    get_default_rmw_implementation(rmw_implementation)
@@ -264,15 +264,15 @@ ELSE() # COLCON_BUILD
         ${PROJECT_NAME} ${typesupport_impl}
       )
    endforeach()
-   
+
    ## Mark executables and/or libraries for installation
-   install(TARGETS 
+   install(TARGETS
       find_object
       ARCHIVE DESTINATION lib
       LIBRARY DESTINATION lib
       RUNTIME DESTINATION bin
    )
-   install(TARGETS 
+   install(TARGETS
       find_object_2d_node
       print_objects_detected
       tf_example

--- a/src/ros2/CameraROS.h
+++ b/src/ros2/CameraROS.h
@@ -35,10 +35,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cv_bridge/cv_bridge.hpp>
 #endif
 
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/sync_policies/exact_time.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
 
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>

--- a/src/ros2/print_objects_detected_node.cpp
+++ b/src/ros2/print_objects_detected_node.cpp
@@ -27,8 +27,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rclcpp/rclcpp.hpp>
 #include <find_object_2d/msg/objects_stamped.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/time_synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/time_synchronizer.hpp>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
 #ifdef PRE_ROS_IRON


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.

message_filter headers are also removed on `rolling`